### PR TITLE
Add Geolocation Methods

### DIFF
--- a/src/services/FrontendService.php
+++ b/src/services/FrontendService.php
@@ -100,7 +100,7 @@ class FrontendService extends Component
             return 'false';
 
         // Generate a cache key based on the user IP
-        $cacheKey = 'geoData_' . $userIP;
+        $cacheKey = 'geoData_' . sha1($userIP);
         $cache = Yii::$app->cache;
 
         // Try to get data from cache to increase speed

--- a/src/services/FrontendService.php
+++ b/src/services/FrontendService.php
@@ -35,6 +35,7 @@ class FrontendService extends Component
         $this->registerVariables();
         $this->registerPluginVariable();
         $this->registertAssets();
+        $this->registerGeo();
     }
 
     public function registerVariables()
@@ -83,5 +84,22 @@ class FrontendService extends Component
             $this->convirza['tel'] = "tel:".SubmissionHelper::cleanPhone($this->convirza['number']);
         }
         return $this->convirza;
+    }
+
+    public function registerGeo()
+    {
+        $geo = $this->getGeo();
+        header('X-LF-Geo: ' . ($geoData?->country ?? 'false'));
+    }
+
+    public function getGeo(): string
+    {
+        if (!empty(Craft::$app->request->userIP)) {
+            try {
+                $geoData = json_decode(file_get_contents('https://api.country.is/' . Craft::$app->request->userIP));
+            } catch (\Exception $e) {}
+        }
+
+        return $geoData?->country ?? 'false';
     }
 }

--- a/src/variables/LeadflexVariable.php
+++ b/src/variables/LeadflexVariable.php
@@ -47,4 +47,9 @@ class LeadflexVariable
     {
         return Leadflex::$plugin->frontend->getConvirza($job);
     }
+
+    public function getGeo() : string
+    {
+        return Leadflex::$plugin->frontend->getGeo();
+    }
 }

--- a/src/variables/LeadflexVariable.php
+++ b/src/variables/LeadflexVariable.php
@@ -1,13 +1,4 @@
 <?php
-/**
- * Reporter plugin for Craft CMS 3.x
- *
- * CIA tool to build reports
- *
- * @link      conversionia.com
- * @copyright Copyright (c) 2023 Jeff Benusa
- */
-
 namespace conversionia\leadflex\variables;
 
 use conversionia\leadflex\Leadflex;
@@ -18,15 +9,15 @@ use craft\errors\InvalidFieldException;
 use modules\businesslogic\BusinessLogic;
 
 /**
- * Reporter Variable
+ * LeadFlex Twig Variables
  *
  * Craft allows plugins to provide their own template variables, accessible from
- * the {{ craft }} global variable (e.g. {{ craft.reporter }}).
+ * the {{ craft }} global variable (e.g. {{ craft.leadflex }}).
  *
  * https://craftcms.com/docs/plugins/variables
  *
- * @author    Jeff Benusa
- * @package   Reporter
+ * @author    Jeff Benusa, JD Griffin
+ * @package   Leadflex
  * @since     1.0.0
  */
 class LeadflexVariable
@@ -48,6 +39,16 @@ class LeadflexVariable
         return Leadflex::$plugin->frontend->getConvirza($job);
     }
 
+    /**
+     * getGeo
+     *
+     * Get the user IP from craft and check it against the country.is API.
+     * Used in twig templates: `{% set userGeo = craft.leadflex.getGeo() %}`
+     *
+     * @since 4.4.0
+     *
+     * @return string Two character country code or 'false' on failure
+     */
     public function getGeo() : string
     {
         return Leadflex::$plugin->frontend->getGeo();


### PR DESCRIPTION
Adds methods to fetch the users geo country based on their IP and then return the country code or false if not found.

Adds a response header called `X-LF-Geo` with the value.

Also adds the ability to check the geo in templates using `craft.leadflex.getGeo()`