### PR TITLE
Version/4/adding referrer configs

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -36,5 +36,8 @@ return [
     "disableCustomSlugGeneration" => false,
 
     // Disable the Job Status = Disabled behavior - "No Campaign ---> No Advertise".
-    "includeJobCampaignEvaluation" => true
+    "includeJobCampaignEvaluation" => true,
+
+    // New configurable setting for the default referrer
+    // 'defaultDirectReferrer' => 'lf_direct',
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -34,4 +34,14 @@ class Settings extends Model
      * @var boolean Disable the Job Status = Disabled behavior - "No Campaign ---> No Advertise".
      */
     public $includeJobCampaignEvaluation = true;
+
+    // Add the new setting with a default value of 'lf_direct'
+    public $defaultDirectReferrer = 'lf_direct';
+
+    public function defineRules(): array
+    {
+        return [
+            [['defaultDirectReferrer'], 'string'],
+        ];
+    }
 }

--- a/src/twigextensions/BusinessLogicTwigExtensions.php
+++ b/src/twigextensions/BusinessLogicTwigExtensions.php
@@ -6,9 +6,17 @@ use Craft;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use yii\web\Cookie;
+use conversionia\leadflex\LeadFlex;  // Import the LeadFlex plugin class to access settings
+
 
 class BusinessLogicTwigExtensions extends AbstractExtension implements GlobalsInterface
 {
+    public function init()
+    {
+        parent::init();
+        // Add this log statement
+        Craft::info('Local LeadFlex plugin loaded!', __METHOD__);
+    }
     private function buildCookie($key, $value, $duration) : Cookie
     {
         $expiry = new \DateTime();
@@ -57,8 +65,10 @@ class BusinessLogicTwigExtensions extends AbstractExtension implements GlobalsIn
 
     public function getGlobals(): array
     {
+        // Get the default referrer from the settings
+        $defaultDirectReferrer = LeadFlex::$plugin->getSettings()->defaultDirectReferrer;
         return [
-            'referrer'      =>  $this->buildCookieValue('r','cookie-monster', "lf_direct"),
+            'referrer'      => $this->buildCookieValue('r', 'cookie-monster', $defaultDirectReferrer),
             'utmSource'     =>  $this->buildCookieValue('utm_source','cookie-monster-utm-source', "leadflex"),
             'utmMedium'     =>  $this->buildCookieValue('utm_medium','cookie-monster-utm-medium', "direct"),
             'utmCampaign'   =>  $this->buildCookieValue('utm_campaign','cookie-monster-utm-campaign', "lf_direct"),

--- a/src/twigextensions/BusinessLogicTwigExtensions.php
+++ b/src/twigextensions/BusinessLogicTwigExtensions.php
@@ -11,12 +11,6 @@ use conversionia\leadflex\LeadFlex;  // Import the LeadFlex plugin class to acce
 
 class BusinessLogicTwigExtensions extends AbstractExtension implements GlobalsInterface
 {
-    public function init()
-    {
-        parent::init();
-        // Add this log statement
-        Craft::info('Local LeadFlex plugin loaded!', __METHOD__);
-    }
     private function buildCookie($key, $value, $duration) : Cookie
     {
         $expiry = new \DateTime();


### PR DESCRIPTION
User can configure a  `config/leadflex.php` to override the default referrer value for the LF plugin.

The following edits were made:
```
/src/models/Settings.php - make make it available as a config (default as lf_direct)

/src/config.php - documented and made easily available

src/twigextensions/BusinessLogicTwigExtensions.php - use the setting (Leadflex::$plugin->getSettings()->defaultDirectReferrer)
```